### PR TITLE
Simple color map

### DIFF
--- a/code/IFSZoom/src/Lib/Picture.hs
+++ b/code/IFSZoom/src/Lib/Picture.hs
@@ -66,11 +66,24 @@ pixelsToColours :: Acc (Matrix Int) -> Acc (Matrix Word32)
 pixelsToColours pixels =
   pixels
   |> Accelerate.map pixelToColour
-  |> Accelerate.map HSL.toRGB
+  -- |> Accelerate.map HSL.toRGB
   |> Accelerate.map RGB.packRGB
   where
-    pixelToColour :: Exp Int -> Exp (HSL Float)
-    pixelToColour pixel = Accelerate.cond (pixel Accelerate.== 0) black white
+    pixelToColour :: Exp Int -> Exp (RGB Float)
+    pixelToColour val =
+      let
+        val' =
+          val
+          |> fromIntegral
+          |> (/ 256)
+          |> sqrt
+          |> sqrt
+      in
+        RGB.rgb val' val' val'
+        |> RGB.clamp
+    -- pixelToColour l = HSL.hsl 0 1.0 ((fromIntegral l) / 255.0)
+    -- pixelToColour :: Exp Int -> Exp (HSL Float)
+    -- pixelToColour pixel = Accelerate.cond (pixel Accelerate.== 0) black white
 
 -- | Turns a point to a pixel coordinate using the given `width` and `height` as picture dimensions.
 --


### PR DESCRIPTION
A very simple implementation that renders pixels using a greyscale colour map with the formula

`sqrt(sqrt(val / 256))` which makes everything not _immediately_ become super dark when zooming in as a simpler linear or square-root map would do.

Nevertheless, it shows how much the colour changes when zooming in/out, which at least rules out 'simple' colour maps.

Possibilities for the future:

- A corrected map where we look for the average density of points to keep the colours roughly the same when zooming in.
- Maybe there are even more clever ways to create a mapping of density to colour that are not prone to this problem.